### PR TITLE
Update process/writing.html and add puzzle status glossary stub

### DIFF
--- a/puzzle_editing/templates/process.html
+++ b/puzzle_editing/templates/process.html
@@ -8,6 +8,7 @@
         <div class="column is-one-fifth">
             <a href="/process/getting-started">Getting Started</a><br>
             <a href="/process/writing">Writing</a><br>
+            <a href="/process/status-glossary">Puzzle Status Glossary</a><br>
         </div>
         <div class="column">
             {% if doc == "getting-started" %}
@@ -18,6 +19,11 @@
             {% if doc == "writing" %}
                 <div id="writing" class="box">
                     {% include "process/writing.html" %}
+                </div>
+            {% endif %}
+            {% if doc == "status-glossary" %}
+                <div id="status-glossary" class="box">
+                    {% include "process/status-glossary.html" %}
                 </div>
             {% endif %}
         </div>

--- a/puzzle_editing/templates/process/status-glossary.html
+++ b/puzzle_editing/templates/process/status-glossary.html
@@ -1,0 +1,9 @@
+<h2 id="puzzle-status-glossary">Puzzle Status Glossary</h2>
+
+<dl>
+  <dt>Initial Idea</dt>
+  <dd>Just an idea, not a puzzle yet. EICs and Lead Editors will evaluate the ideas and move the most promising and highest priority ones on, a few at a time.
+  </dd>
+  <dt>In Development</dt>
+  <dd>Two or three Editors will be assigned to the proposal. Editors and authors develop the idea into a puzzle.</dd>
+</dl>

--- a/puzzle_editing/templates/process/writing.html
+++ b/puzzle_editing/templates/process/writing.html
@@ -1,12 +1,9 @@
 <h2 id="so-you-want-to-write-a-puzzle-yay">So you want to write a puzzle… (yay!)</h2>
 
 <ol type="1">
-  <li>Come up with a puzzle idea
-    <ul>
-      <li>Keep a personal document of puzzle ideas and add to it whenever you think of something or see something that inspires you.</li>
-      <li>Bounce ideas off others in #puzzle-ideas.</li>
-      <li>Reach out to an editor, co-author, or another teammate.</li>
-    </ul>
+  <li> Read our <a href="https://docs.google.com/document/d/1uuS6Gj7tIe2qr_Nd1Gq_Xh6mSyAx7Qi_3bQMD04qemc/edit?usp=sharing">Expectations for Authors (and Editors)</a>.
+  </li>
+  <li> Learn about the <a href="https://docs.google.com/document/d/1Wo4_iRIb0nBEAfg9LmBLwuwO-EY-SHYKopeIPSh03O8/edit#heading=h.x3hos8pcfvfx">lifecycle of a puzzle</a>.
   </li>
   <li>Create a PuzzUp entry for your idea
     <ul>
@@ -14,34 +11,7 @@
       <li>Under “Answer &amp; Round requests”, state what answer constraints your puzzle has and what round you’d prefer it to go in. Editors will do their best to honor these constraints and reach out to you if they can’t be satisfied.</li>
     </ul>
   </li>
-  <li>Get assigned an editor and talk through the puzzle idea with them.</li>
-  <li>Refine your idea and work on proof of concepts based on editor feedback.
-    <ul>
-      <li>Your editor may comment on alternative extraction methods, the puzzle length/scale, and whether or not your puzzle overlaps in content with other puzzles in the hunt.</li>
-      <li>For especially complicated puzzles (lots of constraints, tech work, etc.), you may want to prototype your idea first and solicit feedback from your editor to help determine feasibility.</li>
-    </ul>
-  </li>
-  <li>Your editor assigns an answer and requests a draft of the puzzle.</li>
-  <li>Write the puzzle!
-    <ul>
-      <li>Once you reach this stage, try to provide a draft quickly (~within 2 weeks) so that you can get feedback early since you will likely iterate a lot on it.</li>
-      <li>Your editor should work with you to do a “pre-testsolve” of your puzzle in this draft state. For example, they may try to solve specific crossword clues, help check uniqueness in logic puzzles, and test out any tech prototypes.</li>
-      <li>By the time your puzzle is ready for testsolving, it should be in a solvable state. Testsolves are to help evaluate whether or not the fun and difficulty in your puzzle arises from where you expect them to.</li>
-    </ul>
-  </li>
-  <li>Testsolve your puzzle! See <a href="/process/testsolving">testsolving</a> for more information.</li>
-  <li>Repeat steps 4 through 7 until you have at least 2 clean testsolves.
-    <ul>
-      <li>A clean testsolve is one where testsolvers that were unspoiled prior to starting the puzzle complete it without hints.</li>
-      <li>Revise your puzzles based on what you see happen within 3 days of the testsolve ending (discussing with your editor as needed).</li>
-    </ul>
+  <li>
+    Work with your editors to design, write, test, and finalize the puzzle. For more details about the process, see our <a href="https://docs.google.com/document/d/1Wo4_iRIb0nBEAfg9LmBLwuwO-EY-SHYKopeIPSh03O8/edit#heading=h.x3hos8pcfvfx">lifecycle of a puzzle</a> guide.
   </li>
 </ol>
-
-<hr/>
-<p><em>These final few steps take place after your puzzle is essentially finalized.</em></p>
-<ul>
-  <li>Learn how to postprod and do it!</li>
-  <li>Write canned hints for your puzzle.</li>
-  <li>Write a solution for your puzzle.</li>
-</ul>


### PR DESCRIPTION
* Removes outdated content from `process/writing.html`, replacing it with links to our (draft for now) puzzle lifecycle and expectations docs. I'd like those to remain canonical rather than duplicating the information
* Attempts to add a puzzle status glossary. This requires some annoying reformatting, so I'll hold off on the rest of the content until the other EiCs have approved it, but I wanted to see if my guess about how to do this actually worked, since I don't currently have all the deps set up to run the site locally. 