### PR TITLE
Port the puzzle status glossary from the google doc

### DIFF
--- a/puzzle_editing/templates/process/status-glossary.html
+++ b/puzzle_editing/templates/process/status-glossary.html
@@ -2,115 +2,115 @@
 
 <dl>
 
-<dt>
-Initial Idea
-</dt>
-<dd>
-Just an idea, not a puzzle yet. EICs and Lead Editors will evaluate the ideas and move the most promising and highest priority ones on, a few at a time.
-</dd>
+    <dt>
+        Initial Idea
+    </dt>
+    <dd>
+        Just an idea, not a puzzle yet. EICs and Lead Editors will evaluate the ideas and move the most promising and highest priority ones on, a few at a time.
+    </dd>
 
-<dt>
-In Development
-</dt>
-<dd>
-Two or three Editors will be assigned to the proposal. Editors and authors develop the idea into a puzzle.
-</dd>
+    <dt>
+        In Development
+    </dt>
+    <dd>
+        Two or three Editors will be assigned to the proposal. Editors and authors develop the idea into a puzzle.
+    </dd>
 
-<dt>
-Waiting for Answer
-</dt>
-<dd>Editors have approved the puzzle idea. Waiting until the EiCs have assigned a round and answer to start writing.
-</dd>
+    <dt>
+        Waiting for Answer
+    </dt>
+    <dd>Editors have approved the puzzle idea. Waiting until the EiCs have assigned a round and answer to start writing.
+    </dd>
 
-<dt>
-Writing / Revising (Answer Assigned)
-</dt>
-<dd>The puzzle has been assigned an answer, and the author is writing or revising the puzzle and its draft solution.
-</dd>
+    <dt>
+        Writing / Revising (Answer Assigned)
+    </dt>
+    <dd>The puzzle has been assigned an answer, and the author is writing or revising the puzzle and its draft solution.
+    </dd>
 
 
-<dt>
-Writing / Revising (Answer Flexible)
-</dt>
-<dd>
-The puzzle's answer is flexible (e.g. it produces an instruction that teams can follow to get the "real" answer). The author is writing or revising the puzzle and its draft solution.
-</dd>
+    <dt>
+        Writing / Revising (Answer Flexible)
+    </dt>
+    <dd>
+        The puzzle's answer is flexible (e.g. it produces an instruction that teams can follow to get the "real" answer). The author is writing or revising the puzzle and its draft solution.
+    </dd>
 
-<dt>
-In Testsolving
-</dt>
-<dd>
-At least two editors have approved the puzzle and draft solution via comments in PuzzUp, and the puzzle is ready for testsolving. Test-solving groups can solve the puzzle themselves, and the Head of Testsolving may assign groups to the puzzle.
-</dd>
+    <dt>
+        In Testsolving
+    </dt>
+    <dd>
+        At least two editors have approved the puzzle and draft solution via comments in PuzzUp, and the puzzle is ready for testsolving. Test-solving groups can solve the puzzle themselves, and the Head of Testsolving may assign groups to the puzzle.
+    </dd>
 
-<dt>
-Finalizing Solution
-</dt>
-<dd>
-The Head of Testsolving has approved the clean test solves of the puzzle. The author is now finalizing the solution and canned hints.
-</dd>
+    <dt>
+        Finalizing Solution
+    </dt>
+    <dd>
+        The Head of Testsolving has approved the clean test solves of the puzzle. The author is now finalizing the solution and canned hints.
+    </dd>
 
-<dt>
-Puzzle Written, Waiting for Round
-</dt>
-<dd>
-The puzzle is written with a flexible answer but does not yet have a round assignment. Waiting for the EiCs to do that.
-</dd>
+    <dt>
+        Puzzle Written, Waiting for Round
+    </dt>
+    <dd>
+        The puzzle is written with a flexible answer but does not yet have a round assignment. Waiting for the EiCs to do that.
+    </dd>
 
-<dt>
-Ready for Post-Production
-</dt>
-<dd>
-The puzzle has been tested, the solution is finalized, and the puzzle belongs to a round. It's ready for post-production.
-</dd>
+    <dt>
+        Ready for Post-Production
+    </dt>
+    <dd>
+        The puzzle has been tested, the solution is finalized, and the puzzle belongs to a round. It's ready for post-production.
+    </dd>
 
-<dt>
-Post-Production
-</dt>
-<dd>
-The post-prod team is working on the puzzle.
-</dd>
+    <dt>
+        Post-Production
+    </dt>
+    <dd>
+        The post-prod team is working on the puzzle.
+    </dd>
 
-<dt>
-Factchecking
-</dt>
-<dd>
-Post-production is done, and the final presentation and solution need to be fact-checked.
-</dd>
+    <dt>
+        Factchecking
+    </dt>
+    <dd>
+        Post-production is done, and the final presentation and solution need to be fact-checked.
+    </dd>
 
-<dt>
-Final Revisions
-</dt>
-<dd>
-Fact-checking revealed an issue that the author or post-prod team will need to resolve.
-</dd>
+    <dt>
+        Final Revisions
+    </dt>
+    <dd>
+        Fact-checking revealed an issue that the author or post-prod team will need to resolve.
+    </dd>
 
-<dt>
-Needs Final Day Fact-check
-</dt>
-<dd>
-This puzzle relies on external content that might have changed in between writing and Hunt. We need to make sure nothing in the world changed to break the puzzle.
-</dd>
+    <dt>
+        Needs Final Day Fact-check
+    </dt>
+    <dd>
+        This puzzle relies on external content that might have changed in between writing and Hunt. We need to make sure nothing in the world changed to break the puzzle.
+    </dd>
 
-<dt>
-Done
-</dt>
-<dd>
-Puzzle is ready for Hunt!
-</dd>
+    <dt>
+        Done
+    </dt>
+    <dd>
+        Puzzle is ready for Hunt!
+    </dd>
 
-<dt>
-Deferred
-</dt>
-<dd>
-We don't have time or resources to develop this puzzle right now, but we might later in the year.
-</dd>
+    <dt>
+        Deferred
+    </dt>
+    <dd>
+        We don't have time or resources to develop this puzzle right now, but we might later in the year.
+    </dd>
 
-<dt>
-Dead
-</dt>
-<dd>
-This puzzle idea didn't work, or the author wasn't interested in pursuing it.
-</dd>
+    <dt>
+        Dead
+    </dt>
+    <dd>
+        This puzzle idea didn't work, or the author wasn't interested in pursuing it.
+    </dd>
 
 </dl>


### PR DESCRIPTION
Draft source: https://docs.google.com/document/d/15Y_aSIlAu-xFXkH2wpvPPb4ty4Oxe3DLzj8YrJJT9kM/edit

Once this is merged, I'll mark that draft as deprecated and treat what's in puzzup as canonical. 