### PR TITLE
Make /needs_editor EIC only

### DIFF
--- a/puzzle_editing/views.py
+++ b/puzzle_editing/views.py
@@ -2546,6 +2546,7 @@ def editor_overview(request) -> HttpResponse:
 
 
 @login_required
+@group_required("EIC")
 def needs_editor(request):
     needs_editors = Puzzle.objects.annotate(
         remaining_des=(F("needed_editors") - Count("editors"))


### PR DESCRIPTION
Resolves #56 by limiting the `/needs_editor` URL to the EIC group in case we need it later