### PR TITLE
Highlight expired testsolve sessions

### DIFF
--- a/puzzle_editing/models.py
+++ b/puzzle_editing/models.py
@@ -1293,12 +1293,22 @@ class TestsolveSession(models.Model):
     def get_absolute_url(self):
         return urls.reverse("testsolve_one", kwargs={"id": self.id})
 
+    def get_time_since_started(self):
+        td = datetime.datetime.now(tz=datetime.UTC) - self.started
+        minutes = td.total_seconds() / 60.0
+        hours, minutes = divmod(minutes, 60.0)
+        days, hours = divmod(hours, 24.0)
+        return days, hours, minutes
+
+    @property
+    def is_expired(self):
+        days = self.get_time_since_started()[0]
+        return days >= 2
+
     @property
     def time_since_started(self):
-        td = datetime.datetime.now(tz=datetime.UTC) - self.started
-        minutes = td.seconds / 60
-        hours, minutes = divmod(minutes, 60)
-        days, hours = divmod(hours, 24)
+        days, hours, minutes = self.get_time_since_started()
+
         return " ".join(
             [
                 time

--- a/puzzle_editing/templates/tags/testsolve_session_list.html
+++ b/puzzle_editing/templates/tags/testsolve_session_list.html
@@ -18,6 +18,7 @@
                 {% if coordinator %}
                     <th>Completions</th>
                 {% endif %}
+                <th>Time Elapsed</th>
                 {% if show_notes %}
                     <th>Notes</th>
                 {% endif %}
@@ -45,6 +46,11 @@
                         <td>{{ session.participants|length }} participant(s): {% user_list session.participants linkify=True %}</td>
                         {% if coordinator %}
                             <td>{{ session.get_done_participants_display }}</td>
+                        {% endif %}
+                        {% if session.is_expired %}
+                            <td style="background-color: lightsalmon;">{{ session.time_since_started }}</td>
+                        {% else %}
+                            <td>{{ session.time_since_started }}</td>
                         {% endif %}
                         {% if show_notes %}
                             <td class="small-md">{{ session.notes|markdown }}</td>


### PR DESCRIPTION
Adds a column to `testsolve_session_list` that shows the elapsed time for a testsolve session and highlights it red if > 48 hours. Fixes a bug in the existing "time since started" code to actually make this possible. Resolves #121 