### PR TITLE
Closing a testsolve session is not a feedback comment

### DIFF
--- a/puzzle_editing/views.py
+++ b/puzzle_editing/views.py
@@ -2459,7 +2459,7 @@ def testsolve_close(request: AuthenticatedHttpRequest, id: int) -> HttpResponse:
                     author=user,
                     testsolve_session=session,
                     is_system=False,
-                    is_feedback=True,
+                    is_feedback=False,
                     send_email=False,
                     send_discord=True,
                     content=comment_content,


### PR DESCRIPTION
As per title, bugfix from #125